### PR TITLE
Make Stripe user email optional.

### DIFF
--- a/src/Stripe/Provider.php
+++ b/src/Stripe/Provider.php
@@ -67,7 +67,7 @@ class Provider extends AbstractProvider
 
         return (new User())->setRaw($user)->map([
             'id'   => $user['id'], 'nickname' => $nickname,
-            'name' => null, 'email' => $user['email'], 'avatar' => null,
+            'name' => null, 'email' => $user['email'] ?? null, 'avatar' => null,
         ]);
     }
 


### PR DESCRIPTION
Hi, 👋 

Stripe user emails are not (always?) passed with the response, so it would make sense to make them optional. We've been using a fork in production for a while with this change and it's been working fine.

